### PR TITLE
Fixes spurious warning raised when initializing VectorCells objects.

### DIFF
--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -2065,6 +2065,10 @@ class AgentVectorCells(VectorCells):
         self.params = copy.deepcopy(__class__.default_params)
         self.params.update(params)
 
+        # records whether n was passed as a parameter.
+        if not hasattr(self, "_warn_if_n_changes"):
+            self._warn_if_n_changes = ("n" in params.keys() and params["n"] is not None)
+
         super().__init__(Agent, self.params)
 
         # have a list to detect which agent will the cell detect 

--- a/ratinabox/Neurons.py
+++ b/ratinabox/Neurons.py
@@ -1256,12 +1256,14 @@ class VectorCells(Neurons):
          self.sigma_angles) = self.set_tuning_parameters(**self.params)
 
         # records whether n was passed as a parameter.
-        if not hasattr(self, "_warn_n_change"):
-            self._warn_n_change = ("n" in params.keys() and params["n"] is not None)
+        if not hasattr(self, "_warn_if_n_changes"):
+            self._warn_if_n_changes = ("n" in params.keys() and params["n"] is not None)
 
         # raises a warning if n was passed as a parameter, but will change.
-        if self._warn_n_change:
-            warnings.warn(f"Ignoring 'n' parameter value ({params['n']}) that was passed, and setting number of {self.name} neurons to {len(self.tuning_distances)}, inferred from the cell arrangement parameter.")
+        if self._warn_if_n_changes:
+            dont_check_equality = (isinstance(self.params["cell_arrangement"], str) and self.params["cell_arrangement"].endswith("manifold"))
+            if dont_check_equality or self.n != len(self.tuning_distances):
+                warnings.warn(f"Ignoring 'n' parameter value ({params['n']}) that was passed, and setting number of {self.name} neurons to {len(self.tuning_distances)}, inferred from the cell arrangement parameter.")
         
         self.n = len(self.tuning_distances) # ensure n is correct
  
@@ -1453,8 +1455,8 @@ class BoundaryVectorCells(VectorCells):
         self.params.update(params)
 
         # records whether n was passed as a parameter.
-        if not hasattr(self, "_warn_n_change"):
-            self._warn_n_change = ("n" in params.keys() and params["n"] is not None)
+        if not hasattr(self, "_warn_if_n_changes"):
+            self._warn_if_n_changes = ("n" in params.keys() and params["n"] is not None)
 
         super().__init__(Agent, self.params)
 
@@ -1807,8 +1809,8 @@ class ObjectVectorCells(VectorCells):
         ), "object vector cells only possible in 2D"
 
         # records whether n was passed as a parameter.
-        if not hasattr(self, "_warn_n_change"):
-            self._warn_n_change = ("n" in params.keys() and params["n"] is not None)
+        if not hasattr(self, "_warn_if_n_changes"):
+            self._warn_if_n_changes = ("n" in params.keys() and params["n"] is not None)
 
         super().__init__(Agent, self.params)
 


### PR DESCRIPTION
Fixes mistake I introduced in PR #101, raised in issue #102:
- Reintroduces an equality check in the process of raising a warning if value of self.n was passed, but will be reset internally in a VectorCells class. 
- Equality is checked if `cell_arrangement` does not end in `"manifold"` 
- As a result, if `cell_arrangement` is a callable function (or `"random"`), a warning is only raised if the value of `self.n` would actually change.
- If `cell_arrangement` is `"diverging_manifold"` or `"uniform_manifold"`, a warning is raised even if the value of `n` that was passed happens to match the one calculated internally.