### PR TITLE
Make save folders year first by default.

### DIFF
--- a/ratinabox/utils.py
+++ b/ratinabox/utils.py
@@ -730,7 +730,7 @@ def save_figure(
         return
 
     # make today-specific directory inside figure directory
-    today = datetime.strftime(datetime.now(), "%d_%m_%y")
+    today = datetime.strftime(datetime.now(), "%y_%m_%d")
     figdir = os.path.join(figure_directory, f"{today}")
     os.makedirs(figdir, exist_ok=True)
 


### PR DESCRIPTION
Changed default date formatting of utils.save_figure() to be year first ("%y_%m_%d") instead of day first ("%d_%m_%y").
Day first can be used by called save_figure() with `year_first=False`