### PR TITLE
Fix links in documentation build

### DIFF
--- a/docs/source/get-started/africa.md
+++ b/docs/source/get-started/africa.md
@@ -1,6 +1,6 @@
 # Africa 
 
-This animation was made by students on the [TReND in Africa computational neuroscience summer school](https://trendinafrica.org/computational-neuroscience-basics/). Code is provided below. 
+This animation was made by students on the [TReND in Africa computational neuroscience summer school](https://trendinafrica.org/trend-camina/). Code is provided below. 
 
 <img src="https://raw.githubusercontent.com/RatInABox-Lab/RatInABox/main/.images/readme/riab_africa.gif" width=1000>
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -33,7 +33,7 @@ The top animation shows an example use case: an `Agent` randomly explores a 2D `
 
 
 ## Key features
-* **Non-specific**: Trajectories can be randomly generated, imported, or adaptively controlled making `RatInABox` a powerful engine for many tasks involving continuous motion (e.g. control theory or [reinforcement learning](#policy-control)). 
+* **Non-specific**: Trajectories can be randomly generated, imported, or adaptively controlled making `RatInABox` a powerful engine for many tasks involving continuous motion (e.g. control theory or reinforcement learning). 
 * **Biological**:   Simulate large populations of spatially and/or velocity modulated cell types. Neurons can be rate based or spiking. The random motion model is fitted to match real rodent motion. 
 * **Flexible**:     Simulate environments in 1D or 2D with arbitrarily wall, boundary and hole arrangements.  Combine premade or bespoke `Neurons` classes into arbitrary deep networks (examples given).
 * **Fast**:         Simulating 1 minute of exploration in a 2D environment with 100 place cells (dt=10 ms) take just 2 seconds on a laptop (no GPU needed).


### PR DESCRIPTION
While exploring the repository, I stumbled onto two problems preventing a proper documentation build:

1. A hyperlink to the TrendInAfrica website is broken, as reported by [this failing GitHub action](https://github.com/RatInABox-Lab/RatInABox/actions/runs/12074356335/job/33672209642). This prevents the action from running to its end, and therefore also stops the RatInABox website from being updated. I've replaced the broken link with https://trendinafrica.org/trend-camina/, but feel free to change if another link is a more appropriate target. This is important to unblock future releases.
2. The website's homepage (`index.md`) contains an undefined link: `WARNING: undefined label: '/index.md#policy-control' [ref.ref]`. I suspect this is because this text was copied from the README where the corresponding section exists, but it's not there in `index.md`. I've removed the link in `index.md`, though in practice it was causing no problems since Sphinx was being smart and wouldn't render it as a link.

PS: I discovered this problems by running locally `sphinx-build -b linkcheck docs/source docs/build`, with a RatInABox development environment activated.

I suggest releasing a new patch version `v.1.15.2` after this PR is merged, which will in turn trigger a website build and deployment, to make sure the website is properly up-to-date with the repository.